### PR TITLE
Feat/bare clone option

### DIFF
--- a/cmd/scan/scm.go
+++ b/cmd/scan/scm.go
@@ -18,11 +18,11 @@ var (
 	scanArgs  scan.ScanArgs
 	scmConfig scm.ScmConfig
 
-	noArchived bool
-	sshClone   bool
-	filesOnly  bool
-	noProgress bool
-	bareClone  bool
+	noArchived  bool
+	sshClone    bool
+	filesOnly   bool
+	noProgress  bool
+	noBareClone bool
 
 	verbose bool
 	noColor bool
@@ -78,7 +78,7 @@ func preRun(cmd *cobra.Command, args []string) {
 		scanArgs.ScanType = scan.ScanTypeFilesOnly
 	}
 	scanArgs.ShowProgress = !noProgress
-	scanArgs.BareClone = bareClone
+	scanArgs.BareClone = !noBareClone
 
 	log.Debug().
 		Str("scan_type", scanArgs.ScanType.String()).
@@ -109,7 +109,7 @@ func registerCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&scannerTrufflehogPath, "scanner-trufflehog-path", "trufflehog", "Custom path to the trufflehog binary")
 	cmd.Flags().BoolVar(&filesOnly, "files-only", false, "Only run the scan on the files of the default branch")
 	cmd.Flags().BoolVar(&noProgress, "no-progress", false, "Hide progress bar during scan")
-	cmd.Flags().BoolVar(&bareClone, "bare-clone", false, "Clone repositories as bare (no working directory, .gitleaks.toml will be ignored)")
+	cmd.Flags().BoolVar(&noBareClone, "no-bare-clone", false, "Clone repositories with working directory")
 
 	// log flags
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output")

--- a/cmd/scan/scm.go
+++ b/cmd/scan/scm.go
@@ -22,6 +22,7 @@ var (
 	sshClone   bool
 	filesOnly  bool
 	noProgress bool
+	bareClone  bool
 
 	verbose bool
 	noColor bool
@@ -77,6 +78,7 @@ func preRun(cmd *cobra.Command, args []string) {
 		scanArgs.ScanType = scan.ScanTypeFilesOnly
 	}
 	scanArgs.ShowProgress = !noProgress
+	scanArgs.BareClone = bareClone
 
 	log.Debug().
 		Str("scan_type", scanArgs.ScanType.String()).
@@ -86,6 +88,7 @@ func preRun(cmd *cobra.Command, args []string) {
 		Str("baseline_path", scanArgs.BaselinePath).
 		Int("max_concurrency", scanArgs.MaxConcurrency).
 		Bool("show_progress", scanArgs.ShowProgress).
+		Bool("bare_clone", scanArgs.BareClone).
 		Msg("parsed scan args")
 }
 
@@ -106,6 +109,7 @@ func registerCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&scannerTrufflehogPath, "scanner-trufflehog-path", "trufflehog", "Custom path to the trufflehog binary")
 	cmd.Flags().BoolVar(&filesOnly, "files-only", false, "Only run the scan on the files of the default branch")
 	cmd.Flags().BoolVar(&noProgress, "no-progress", false, "Hide progress bar during scan")
+	cmd.Flags().BoolVar(&bareClone, "bare-clone", false, "Clone repositories as bare (no working directory, .gitleaks.toml will be ignored)")
 
 	// log flags
 	cmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output")

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -86,14 +86,15 @@ type ScanArgs struct {
 	BaselinePath           string
 	MaxConcurrency         int
 	ShowProgress           bool
+	BareClone              bool
 }
 
-func repoScanTask(ctx context.Context, repository string, s scm.Scm, full bool, w report.ReportWriter) error {
+func repoScanTask(ctx context.Context, repository string, s scm.Scm, full bool, bareClone bool, w report.ReportWriter) error {
 	destination := path.Join(utils.TempDirPath(), repository)
 
 	url := s.GitRepoUrl(repository)
 
-	err := git.Clone(ctx, url, destination, !full, true)
+	err := git.Clone(ctx, url, destination, !full, bareClone, true)
 	if err != nil {
 		// if remote is empty, scan next repository
 		if errors.Is(err, transport.ErrEmptyRemoteRepository) {
@@ -170,7 +171,7 @@ func Scan(ctx context.Context, s scm.Scm, args ScanArgs) error {
 	for _, repo := range repos {
 		repo := repo // closure
 		tasks = append(tasks, progress.NewTask(func(ctx context.Context) error {
-			return repoScanTask(ctx, repo, s, args.ScanType == ScanTypeFull, writer)
+			return repoScanTask(ctx, repo, s, args.ScanType == ScanTypeFull, args.BareClone, writer)
 		}))
 	}
 

--- a/internal/scan/scanners/ignore_test.go
+++ b/internal/scan/scanners/ignore_test.go
@@ -12,7 +12,7 @@ import (
 var testPath string = path.Join(utils.TempDirPath(), "tests")
 
 func TestIsLineIgnored(t *testing.T) {
-	err := git.Clone(context.Background(), "https://github.com/gitleaks/gitleaks", path.Join(testPath, "gitleaks"), false, true)
+	err := git.Clone(context.Background(), "https://github.com/gitleaks/gitleaks", path.Join(testPath, "gitleaks"), false, false, true)
 	if err != nil {
 		t.Fatalf(`git.Clone("https://github.com/gitleaks/gitleaks", ...) = %v, nil`, err)
 	}
@@ -24,7 +24,7 @@ func TestIsLineIgnored(t *testing.T) {
 		t.Fatalf(`IsLineIgnored(gitleaks, "abfd0f3fdcb7925ff94184fba67b5d444cc42f92", ...) = %t, %v, want %t, nil`, test, err, want)
 	}
 
-	err = git.Clone(context.Background(), "https://github.com/trufflesecurity/trufflehog", path.Join(testPath, "trufflehog"), false, true)
+	err = git.Clone(context.Background(), "https://github.com/trufflesecurity/trufflehog", path.Join(testPath, "trufflehog"), false, false, true)
 	if err != nil {
 		t.Fatalf(`git.Clone("https://github.com/trufflesecurity/trufflehog", ...) = %v, nil`, err)
 	}

--- a/internal/scm/git/clone.go
+++ b/internal/scm/git/clone.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
-func Clone(ctx context.Context, url string, destination string, shallow bool, fetchIfExists bool) error {
+func Clone(ctx context.Context, url string, destination string, shallow bool, bare bool, fetchIfExists bool) error {
 	opts := &git.CloneOptions{URL: url}
 	if shallow {
 		opts.SingleBranch = true
@@ -16,7 +16,7 @@ func Clone(ctx context.Context, url string, destination string, shallow bool, fe
 		opts.Depth = 1
 	}
 
-	_, err := git.PlainCloneContext(ctx, destination, true, opts)
+	_, err := git.PlainCloneContext(ctx, destination, bare, opts)
 	if err != nil {
 		// if the path already exists, it means the repostiory has already been cloned and it is not an error
 		if errors.Is(err, git.ErrRepositoryAlreadyExists) {


### PR DESCRIPTION
Adds a --no-bare-clone option to be be able to handle in repo files like .gitleaks.toml
If not set, defaults to a bare clone to preserve current operating mode